### PR TITLE
Fix bump 1.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,3 @@
-# v1.5.1 (Fri Jan 13 2023)
-
-#### 🐛 Bug Fix
-
-- Hilo challenge sensor support [#23](https://github.com/SanterreJo/homebridge-hilo/pull/23) ([@SanterreJo](https://github.com/SanterreJo))
-
-#### Authors: 1
-
-- Jonathan Santerre ([@SanterreJo](https://github.com/SanterreJo))
-
----
-
 # v1.5.0 (Mon Nov 21 2022)
 
 #### 🚀 Enhancement


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.6.0--canary.24.c526183.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install homebridge-hilo@1.6.0--canary.24.c526183.0
  # or 
  yarn add homebridge-hilo@1.6.0--canary.24.c526183.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
