### PR TITLE
Add challenge phases sensors for more granularity (#27)

### DIFF
--- a/src/devices/HiloChallengeSensor.ts
+++ b/src/devices/HiloChallengeSensor.ts
@@ -20,6 +20,25 @@ type Challenge = {
 };
 type EventsResponse = Array<Challenge>;
 
+const phases: Record<
+	string,
+	| { start: keyof Challenge["phases"]; end: keyof Challenge["phases"] }
+	| undefined
+> = {
+	preheat: {
+		start: "preheatStartDateUTC",
+		end: "preheatEndDateUTC",
+	},
+	reduction: {
+		start: "reductionStartDateUTC",
+		end: "reductionEndDateUTC",
+	},
+	recovery: {
+		start: "recoveryStartDateUTC",
+		end: "recoveryEndDateUTC",
+	},
+};
+
 export class HiloChallengeSensor extends HiloDevice<"Challenge"> {
 	private challenges: Record<number, NodeJS.Timeout[]> = {};
 	constructor(
@@ -100,12 +119,19 @@ export class HiloChallengeSensor extends HiloDevice<"Challenge"> {
 			return;
 		}
 		this.challenges[challenge.id] = [];
+		const devicePhase = this.device.assetId.split("-")[0];
+		const startPhase = phases[devicePhase]?.start;
+		const endPhase = phases[devicePhase]?.end;
+		if (!startPhase || !endPhase) {
+			this.logger.error(
+				`Could not find phase for device ${this.device.assetId}`
+			);
+			return;
+		}
 		const startsIn =
-			new Date(challenge.phases.preheatStartDateUTC).getTime() -
-			new Date().getTime();
+			new Date(challenge.phases[startPhase]).getTime() - new Date().getTime();
 		const endsIn =
-			new Date(challenge.phases.recoveryEndDateUTC).getTime() -
-			new Date().getTime();
+			new Date(challenge.phases[endPhase]).getTime() - new Date().getTime();
 		this.challenges[challenge.id].push(
 			setTimeout(
 				() => {

--- a/src/devices/HiloChallengeSensor.ts
+++ b/src/devices/HiloChallengeSensor.ts
@@ -1,24 +1,6 @@
 import { API, CharacteristicValue, PlatformAccessory } from "homebridge";
-import { eventsApi } from "../hiloApi";
 import { HiloDevice } from "./HiloDevice";
-import { DeviceValue, HiloAccessoryContext } from "./types";
-
-type Challenge = {
-	progress: string;
-	isParticipating: boolean;
-	isConfigurable: boolean;
-	id: number;
-	period: "am" | "pm";
-	phases: {
-		preheatStartDateUTC: string;
-		preheatEndDateUTC: string;
-		reductionStartDateUTC: string;
-		reductionEndDateUTC: string;
-		recoveryStartDateUTC: string;
-		recoveryEndDateUTC: string;
-	};
-};
-type EventsResponse = Array<Challenge>;
+import { Challenge, DeviceValue, HiloAccessoryContext } from "./types";
 
 const phases: Record<
 	string,
@@ -56,10 +38,6 @@ export class HiloChallengeSensor extends HiloDevice<"Challenge"> {
 		this.service
 			.getCharacteristic(this.api.hap.Characteristic.ContactSensorState)
 			.onGet(this.getContactSensorState.bind(this));
-		setInterval(async () => {
-			this.updateChallengeStatus();
-		}, /* 1 hour */ 60 * 60 * 1000);
-		this.updateChallengeStatus();
 	}
 
 	updateValue(
@@ -81,25 +59,16 @@ export class HiloChallengeSensor extends HiloDevice<"Challenge"> {
 		return activeChallenge;
 	}
 
-	private async updateChallengeStatus() {
-		try {
-			const response = await eventsApi.get<EventsResponse>(
-				`/Locations/${this.device.locationId}/Events`,
-				{ params: { active: true } }
-			);
-			const challenges = response.data;
-			challenges.forEach((challenge) => {
-				challenge.isParticipating
-					? this.participating(challenge)
-					: this.notParticipating(challenge);
-			});
-			if (
-				challenges.filter((challenge) => challenge.isParticipating).length === 0
-			) {
-				this.updateChallengeValue(false);
-			}
-		} catch (error) {
-			this.logger.error("Could not retrieve Hilo Challenges", error);
+	async updateChallengeStatus(challenges: Challenge[]) {
+		challenges.forEach((challenge) => {
+			challenge.isParticipating
+				? this.participating(challenge)
+				: this.notParticipating(challenge);
+		});
+		if (
+			challenges.filter((challenge) => challenge.isParticipating).length === 0
+		) {
+			this.updateChallengeValue(false);
 		}
 	}
 
@@ -132,23 +101,26 @@ export class HiloChallengeSensor extends HiloDevice<"Challenge"> {
 			new Date(challenge.phases[startPhase]).getTime() - new Date().getTime();
 		const endsIn =
 			new Date(challenge.phases[endPhase]).getTime() - new Date().getTime();
-		this.challenges[challenge.id].push(
-			setTimeout(
-				() => {
+		if (startsIn >= 0) {
+			this.challenges[challenge.id].push(
+				setTimeout(() => {
 					this.updateChallengeValue(true);
-				},
-				startsIn < 0 ? 0 : startsIn
-			)
-		);
-		this.challenges[challenge.id].push(
-			setTimeout(
-				() => {
+				}, startsIn)
+			);
+		} else if (startsIn < 0 && endsIn > 0) {
+			this.updateChallengeValue(true);
+		}
+		if (endsIn >= 0) {
+			this.challenges[challenge.id].push(
+				setTimeout(() => {
 					this.updateChallengeValue(false);
 					delete this.challenges[challenge.id];
-				},
-				endsIn < 0 ? 0 : endsIn
-			)
-		);
+				}, endsIn)
+			);
+		} else {
+			this.updateChallengeValue(false);
+			delete this.challenges[challenge.id];
+		}
 	}
 
 	private notParticipating(challenge: Challenge) {

--- a/src/devices/types.ts
+++ b/src/devices/types.ts
@@ -111,6 +111,23 @@ type DeviceValueAttributeMap<T extends Device["type"]> = T extends LightType
 	? ChallengeDeviceValue
 	: never;
 
+export type Challenge = {
+	progress: string;
+	isParticipating: boolean;
+	isConfigurable: boolean;
+	id: number;
+	period: "am" | "pm";
+	phases: {
+		preheatStartDateUTC: string;
+		preheatEndDateUTC: string;
+		reductionStartDateUTC: string;
+		reductionEndDateUTC: string;
+		recoveryStartDateUTC: string;
+		recoveryEndDateUTC: string;
+	};
+};
+export type EventsResponse = Array<Challenge>;
+
 export type HiloAccessoryContext<T extends Device["type"] = Device["type"]> = {
 	values: Partial<{
 		[P in DeviceValue["attribute"]]: Extract<

--- a/src/hilo.ts
+++ b/src/hilo.ts
@@ -73,15 +73,7 @@ class Hilo implements DynamicPlatformPlugin {
 			) {
 				// Add Hilo Challenge sensor for each location
 				this.locations.forEach((location) => {
-					devices.push({
-						assetId: `hilo-challenge-${location.id}`,
-						id: location.id,
-						name: `Hilo Challenge ${location.name}`,
-						type: "Challenge",
-						locationId: location.id,
-						modelNumber: "Hilo Challenge",
-						identifier: `hilo-challenge-${location.id}`,
-					});
+					devices.push(...getHiloChallengeDevices(location));
 				});
 			}
 			devices.forEach((device) => {
@@ -265,3 +257,33 @@ async function fetchDevices(location: Location) {
 		return [];
 	}
 }
+
+const getHiloChallengeDevices = (location: Location): Device[] => [
+	{
+		assetId: `preheat-hilo-challenge-${location.id}`,
+		id: location.id + 100,
+		name: `Preheat - Hilo Challenge ${location.name}`,
+		type: "Challenge",
+		locationId: location.id,
+		modelNumber: "Hilo Challenge",
+		identifier: `preheat-hilo-challenge-${location.id}`,
+	},
+	{
+		assetId: `reduction-hilo-challenge-${location.id}`,
+		id: location.id + 101,
+		name: `Reduction - Hilo Challenge ${location.name}`,
+		type: "Challenge",
+		locationId: location.id,
+		modelNumber: "Hilo Challenge",
+		identifier: `reduction-hilo-challenge-${location.id}`,
+	},
+	{
+		assetId: `recovery-hilo-challenge-${location.id}`,
+		id: location.id + 102,
+		name: `Recovery - Hilo Challenge ${location.name}`,
+		type: "Challenge",
+		locationId: location.id,
+		modelNumber: "Hilo Challenge",
+		identifier: `recovery-hilo-challenge-${location.id}`,
+	},
+];

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,8 @@
 		"rootDir": "./src",
 		"strict": true,
 		"esModuleInterop": true,
-		"noImplicitAny": true
+		"noImplicitAny": true,
+		"skipLibCheck": true,
 	},
 	"include": ["src/"],
 	"exclude": ["**/*.spec.ts"]


### PR DESCRIPTION
Now 3 sensors are available for each phase (Preheat, Reduction and Recovery)

BREAKING: Old sensor that spanned all three phases is now removed

Closes #26
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
# Version

Published prerelease version: `v1.7.0-next.1`

<details>
  <summary>Changelog</summary>

  #### 🚀 Enhancement
  
  - Add challenge sensors for more granularity [#27](https://github.com/SanterreJo/homebridge-hilo/pull/27) ([@SanterreJo](https://github.com/SanterreJo))
  
  #### ⚠️ Pushed to `next`
  
  - Fix challenge sensors going on and off ([@SanterreJo](https://github.com/SanterreJo))
  
  #### Authors: 1
  
  - Jonathan Santerre ([@SanterreJo](https://github.com/SanterreJo))
</details>
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
