### PR TITLE
Handle new websocket channels

### DIFF
--- a/src/hilo.ts
+++ b/src/hilo.ts
@@ -177,6 +177,12 @@ class Hilo implements DynamicPlatformPlugin {
 				pluginAccessory.updateValue(value as any);
 			});
 		});
+		connection.on("GatewayValuesReceived", (message: any) => {
+			this.log.debug(`GatewayValuesReceived:`, message);
+		});
+		connection.on("DeviceListInitialValuesReceived", (message: any) => {
+			this.log.debug(`DeviceListInitialValuesReceived`, message);
+		});
 		connection.onreconnecting(() => {
 			this.log.info("Reconnecting to websocket");
 		});


### PR DESCRIPTION
fixes #32
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.8.1--canary.33.9af010a.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install homebridge-hilo@1.8.1--canary.33.9af010a.0
  # or 
  yarn add homebridge-hilo@1.8.1--canary.33.9af010a.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
