### PR TITLE
Update doc for deprecated auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
+⚠️ Hilo a retiré la méthode de connexion par nom d'utilisateur et mot de passe à partir du 10 avril 2024. Le plugin ne fonctionnera plus jusqu'à ce qu'une nouvelle version soit publiée ⚠️
+
+⚠️ Hilo deprecated the username/password login method as of April 10th 2024. The plugin will no longer work until a new version is released ⚠️
+
+
 # homebridge-hilo
 [![verified-by-homebridge](https://badgen.net/badge/homebridge/verified/purple)](https://github.com/homebridge/homebridge/wiki/Verified-Plugins)
 [![npm-version](https://badgen.net/npm/v/homebridge-hilo)](https://www.npmjs.com/package/homebridge-hilo)

--- a/src/hiloApi.ts
+++ b/src/hiloApi.ts
@@ -193,8 +193,13 @@ const authInterceptor = async (config: AxiosRequestConfig) => {
 
 hiloApi.interceptors.request.use(authInterceptor);
 
-const unableToLogin = (e: unknown) =>
-	getLogger().error(
-		"Unable to login",
-		axios.isAxiosError(e) ? e.response?.data : e
+const unableToLogin = (e: unknown) => {
+	const logger = getLogger();
+	logger.error("Unable to login", axios.isAxiosError(e) ? e.response?.data : e);
+	logger.error(
+		"Hilo deprecated the username/password login method as of April 10th 2024. The plugin will no longer work until a new version is released"
 	);
+	logger.error(
+		"Hilo a retiré la méthode de connexion par nom d'utilisateur et mot de passe à partir du 10 avril 2024. Le plugin ne fonctionnera plus jusqu'à ce qu'une nouvelle version soit publiée"
+	);
+};


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.10.0--canary.49.754dc64.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install homebridge-hilo@1.10.0--canary.49.754dc64.0
  # or 
  yarn add homebridge-hilo@1.10.0--canary.49.754dc64.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
