### PR TITLE
Homebridge 2.0 compat

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Note: Ceci n'est pas un plugin officiel, le plugin n'est pas affilié avec Hilo 
 ## Installation
 1. Installer Homebridge en suivant
    [les instructions](https://github.com/homebridge/homebridge/wiki).
-2. Installer le plugin en utilisant [Homebridge Config UI X (REQUIS)](https://github.com/oznu/homebridge-config-ui-x), ou en exécutant `npm install -g homebridge-hilo`.
+2. Installer le plugin en utilisant [Homebridge Config UI X (REQUIS)](https://github.com/oznu/homebridge-config-ui-x).
 
 ## Configuration
 Pour que le plugin soit fonctionnel, il doit avoir accès à votre compte Hilo
@@ -65,7 +65,7 @@ Note: This is not an official plugin, this plugin is not affiliated with Hilo no
 ## Installation
 1. Install Homebridge by following
    [the instructions](https://github.com/homebridge/homebridge/wiki).
-2. Install this plugin using [Homebridge Config UI X (REQUIRED)](https://github.com/oznu/homebridge-config-ui-x), or by running `npm install -g homebridge-hilo`.
+2. Install this plugin using [Homebridge Config UI X (REQUIRED)](https://github.com/oznu/homebridge-config-ui-x).
 
 ## Configuration
 For the plugin to work, it needs access to your Hilo account

--- a/config.schema.json
+++ b/config.schema.json
@@ -7,13 +7,13 @@
 		"type": "object",
 		"properties": {
 			"noChallengeSensor": {
-				"title": "No Challenge Sensor",
+				"title": "Désactiver les capteurs de défis Hilo / No Challenge Sensor",
 				"type": "boolean",
 				"default": false,
 				"required": true
 			},
 			"plannedHours": {
-				"title": "Trigger planned challenge sensor X hours before preheat phase",
+				"title": "Activer le capteur d'un défi planifié X heures avant la phase de préchauffage / Trigger planned challenge sensor X hours before preheat phase",
 				"type": "number",
 				"default": 2,
 				"minimum": 1,
@@ -21,7 +21,7 @@
 				"required": false
 			},
 			"refreshToken": {
-				"title": "Refresh Token - This field is automatically populated by the 'Login with Hilo' button",
+				"title": "Jetons d'authentification - Ce champ est automatiquement généré à partir du bouton 'Se connecter avec Hilo' / Refresh Token - This field is automatically populated by the 'Login with Hilo' button",
 				"type": "string",
 				"required": true
 			}

--- a/homebridge-ui/public/index.html
+++ b/homebridge-ui/public/index.html
@@ -1,9 +1,25 @@
 <div class="card">
 	<ol>
+		<li>Vous devrez connaître l'adresse IP ou le nom de domaine que vous utilisez pour vous connecter à homebridge. Habituellement, ce sera l'adresse dans votre navigateur</li>
+		<li>Cliquez sur le bouton ci-dessous pour démarrer le processus d'authentification</li>
+		<li>Connectez-vous à votre compte hilo</li>
+		<li>Entrez l'adresse IP ou le nom de domaine que vous avez noté à l'étape 1 et ajoutez le port 8880 à la fin. Exemples : http://192.168.0.10:8880 http://homebridge.local:8880
+			<ul>
+				<li>Remarque : Selon la façon dont vous avez configuré votre serveur homebridge, vous devrez vous assurer que le port 8880 est routé vers votre serveur homebridge. Par exemple, pour une configuration docker, vous devrez ajouter `-p 8880:8880` à votre commande docker. Si vous utilisez un proxy inverse, vous devrez ajouter le port 8880 à votre configuration</li>
+			</ul>
+		</li>
+		<li>Cliquez sur le bouton "Enregistrer", puis cliquez sur le bouton "Lier le compte"</li>
+		<li>Vous pouvez enregistrer votre configuration et redémarrer votre serveur homebridge</li>
+	</ol>
+	<button type="button" class="btn btn-primary" onclick="initiateAuth()">
+		Se connecter avec Hilo
+	</button>
+	<br><br>
+	<ol>
 		<li>You will need to know the IP address or the domain name you use to connect to homebridge. Usually it will be the address in your browser</li>
 		<li>Click on the button below to start the authentication process</li>
 		<li>Login to your hilo account</li>
-		<li>Enter the ip address or domain name you took not at step 1 and add the port 8880 at the end. Examples: http://192.168.0.10:8880 http://homebridge.local:8880
+		<li>Enter the ip address or domain name you took note of at step 1 and add the port 8880 at the end. Examples: http://192.168.0.10:8880 http://homebridge.local:8880
 			<ul>
 				<li>Note: Depending on how you have configured your homebridge server, you will need to ensure that port 8880 is routed to your homebridge server. For example for a docker configuration you will need to add `-p 8880:8880` to your docker command. If you are using a reverse proxy, you will need to add port 8880 to your configuration</li>
 			</ul>
@@ -17,16 +33,16 @@
 </div>
 <script>
 	homebridge.showSchemaForm();
-        async function initiateAuth() {
-                const { authorizationURL } = await homebridge.request('/autorizationUrl');
-                const callback = homebridge.request('/callback');
+	async function initiateAuth() {
+		const { authorizationURL } = await homebridge.request('/autorizationUrl');
+		const callback = homebridge.request('/callback');
 
-                window.open(authorizationURL, "_blank");
+		window.open(authorizationURL, "_blank");
 
-                const { accessToken, refreshToken, expiresIn } = await callback;
-                const [config, ...otherConfigs] = await homebridge.getPluginConfig();
-                await homebridge.updatePluginConfig([{ ...config, refreshToken }, ...otherConfigs]);
-                await homebridge.savePluginConfig();
-                homebridge.toast.success("Successfully authenticated with Hilo");
-        }
+		const { accessToken, refreshToken, expiresIn } = await callback;
+		const [config, ...otherConfigs] = await homebridge.getPluginConfig();
+		await homebridge.updatePluginConfig([{ ...config, refreshToken }, ...otherConfigs]);
+		await homebridge.savePluginConfig();
+		homebridge.toast.success("Successfully authenticated with Hilo");
+	}
 </script>

--- a/package-lock.json
+++ b/package-lock.json
@@ -43,8 +43,8 @@
 				"typescript": "^4.7.4"
 			},
 			"engines": {
-				"homebridge": ">1.4.0",
-				"node": ">=16.0.0"
+				"homebridge": "^1.6.0 || ^2.0.0-beta.0",
+				"node": "^18.20.4 || ^20.15.1"
 			}
 		},
 		"node_modules/@auto-it/bot-list": {

--- a/package.json
+++ b/package.json
@@ -4,9 +4,9 @@
 	"description": "Plugin Homebridge (non officiel) pour la passerelle et les appareils Hilo de Hydro-Québec | Unofficial Homebridge plugin for Hydro-Québec Hilo bridge and devices",
 	"main": "dist/hilo.js",
 	"engines": {
-		"node": ">=16.0.0",
-		"homebridge": ">1.4.0"
-	},
+	    "homebridge": "^1.6.0 || ^2.0.0-beta.0",
+	    "node": "^18.20.4 || ^20.15.1"
+  	},
 	"scripts": {
 		"lint": "eslint src/**.ts --max-warnings=0",
 		"build": "rimraf dist/ && tsc",

--- a/src/devices/Thermostat.ts
+++ b/src/devices/Thermostat.ts
@@ -22,7 +22,6 @@ export class Thermostat extends HiloDevice<"Thermostat"> {
 			.onGet(this.getCurrentHeatingCoolingState.bind(this))
 			.setProps({
 				validValues: [
-					this.api.hap.Characteristic.CurrentHeatingCoolingState.OFF,
 					this.api.hap.Characteristic.CurrentHeatingCoolingState.HEAT,
 				],
 				maxValue: this.api.hap.Characteristic.CurrentHeatingCoolingState.HEAT,
@@ -33,9 +32,9 @@ export class Thermostat extends HiloDevice<"Thermostat"> {
 			.onSet(this.setTargetHeatingCoolingState.bind(this))
 			.setProps({
 				validValues: [
-					this.api.hap.Characteristic.TargetHeatingCoolingState.AUTO,
+					this.api.hap.Characteristic.TargetHeatingCoolingState.HEAT,
 				],
-				maxValue: this.api.hap.Characteristic.TargetHeatingCoolingState.AUTO,
+				maxValue: this.api.hap.Characteristic.TargetHeatingCoolingState.HEAT,
 			});
 		this.service
 			.getCharacteristic(this.api.hap.Characteristic.CurrentTemperature)
@@ -76,9 +75,7 @@ export class Thermostat extends HiloDevice<"Thermostat"> {
 						this.api.hap.Characteristic.CurrentHeatingCoolingState
 					)
 					?.updateValue(
-						value?.value
-							? this.api.hap.Characteristic.CurrentHeatingCoolingState.HEAT
-							: this.api.hap.Characteristic.CurrentHeatingCoolingState.OFF
+						this.api.hap.Characteristic.CurrentHeatingCoolingState.HEAT
 					);
 				break;
 		}
@@ -86,14 +83,12 @@ export class Thermostat extends HiloDevice<"Thermostat"> {
 
 	private async getCurrentHeatingCoolingState(): Promise<CharacteristicValue> {
 		this.logger.debug(`Getting ${this.device.name} currentHeatingCoolingState`);
-		return this.values.Heating?.value
-			? this.api.hap.Characteristic.CurrentHeatingCoolingState.HEAT
-			: this.api.hap.Characteristic.CurrentHeatingCoolingState.OFF;
+		return this.api.hap.Characteristic.CurrentHeatingCoolingState.HEAT;
 	}
 
 	private async getTargetHeatingCoolingState(): Promise<CharacteristicValue> {
 		this.logger.debug(`Getting ${this.device.name} targetHeatingCoolingState`);
-		return this.api.hap.Characteristic.TargetHeatingCoolingState.AUTO;
+		return this.api.hap.Characteristic.TargetHeatingCoolingState.HEAT;
 	}
 
 	private async setTargetHeatingCoolingState(value: CharacteristicValue) {

--- a/src/devices/Thermostat.ts
+++ b/src/devices/Thermostat.ts
@@ -22,6 +22,7 @@ export class Thermostat extends HiloDevice<"Thermostat"> {
 			.onGet(this.getCurrentHeatingCoolingState.bind(this))
 			.setProps({
 				validValues: [
+					this.api.hap.Characteristic.CurrentHeatingCoolingState.OFF,
 					this.api.hap.Characteristic.CurrentHeatingCoolingState.HEAT,
 				],
 				maxValue: this.api.hap.Characteristic.CurrentHeatingCoolingState.HEAT,
@@ -75,7 +76,9 @@ export class Thermostat extends HiloDevice<"Thermostat"> {
 						this.api.hap.Characteristic.CurrentHeatingCoolingState
 					)
 					?.updateValue(
-						this.api.hap.Characteristic.CurrentHeatingCoolingState.HEAT
+						value?.value
+							? this.api.hap.Characteristic.CurrentHeatingCoolingState.HEAT
+							: this.api.hap.Characteristic.CurrentHeatingCoolingState.OFF
 					);
 				break;
 		}
@@ -83,7 +86,9 @@ export class Thermostat extends HiloDevice<"Thermostat"> {
 
 	private async getCurrentHeatingCoolingState(): Promise<CharacteristicValue> {
 		this.logger.debug(`Getting ${this.device.name} currentHeatingCoolingState`);
-		return this.api.hap.Characteristic.CurrentHeatingCoolingState.HEAT;
+		return this.values.Heating?.value
+			? this.api.hap.Characteristic.CurrentHeatingCoolingState.HEAT
+			: this.api.hap.Characteristic.CurrentHeatingCoolingState.OFF;
 	}
 
 	private async getTargetHeatingCoolingState(): Promise<CharacteristicValue> {

--- a/src/hilo.ts
+++ b/src/hilo.ts
@@ -123,7 +123,7 @@ class Hilo implements DynamicPlatformPlugin {
 	): PlatformAccessory<HiloAccessoryContext> {
 		const uuid = this.api.hap.uuid.generate(device.assetId);
 		const accessory = new this.api.platformAccessory<HiloAccessoryContext>(
-			cleanupDeviceName(device.name),
+			device.name.trim(),
 			uuid
 		);
 		accessory.context.device = device;
@@ -373,7 +373,3 @@ const getHiloChallengeDevices = (location: Location): Device[] => [
 		identifier: `inProgress-hilo-challenge-${location.id}`,
 	},
 ];
-
-function cleanupDeviceName(name: string): string {
-	return name.replace(/[^a-zA-Z0-9'\s]/g, " ").trim();
-}

--- a/src/hilo.ts
+++ b/src/hilo.ts
@@ -23,7 +23,7 @@ import axios from "axios";
 import { HiloDevice } from "./devices/HiloDevice";
 import { HiloChallengeSensor } from "./devices/HiloChallengeSensor";
 
-const PLUGIN_NAME = "homebridge-hilo";
+const PLUGIN_NAME = "homebridge hilo";
 const PLATFORM_NAME = "Hilo";
 
 export default function (api: API) {

--- a/src/hilo.ts
+++ b/src/hilo.ts
@@ -123,7 +123,7 @@ class Hilo implements DynamicPlatformPlugin {
 	): PlatformAccessory<HiloAccessoryContext> {
 		const uuid = this.api.hap.uuid.generate(device.assetId);
 		const accessory = new this.api.platformAccessory<HiloAccessoryContext>(
-			device.name,
+			cleanupDeviceName(device.name),
 			uuid
 		);
 		accessory.context.device = device;
@@ -321,7 +321,7 @@ const getHiloChallengeDevices = (location: Location): Device[] => [
 	{
 		assetId: `preheat-hilo-challenge-${location.id}`,
 		id: location.id + 100,
-		name: `Preheat - Hilo Challenge ${location.name}`,
+		name: `Preheat Hilo Challenge ${location.name}`,
 		type: "Challenge",
 		locationId: location.id,
 		modelNumber: "Hilo Challenge",
@@ -330,7 +330,7 @@ const getHiloChallengeDevices = (location: Location): Device[] => [
 	{
 		assetId: `reduction-hilo-challenge-${location.id}`,
 		id: location.id + 101,
-		name: `Reduction - Hilo Challenge ${location.name}`,
+		name: `Reduction Hilo Challenge ${location.name}`,
 		type: "Challenge",
 		locationId: location.id,
 		modelNumber: "Hilo Challenge",
@@ -339,7 +339,7 @@ const getHiloChallengeDevices = (location: Location): Device[] => [
 	{
 		assetId: `recovery-hilo-challenge-${location.id}`,
 		id: location.id + 102,
-		name: `Recovery - Hilo Challenge ${location.name}`,
+		name: `Recovery Hilo Challenge ${location.name}`,
 		type: "Challenge",
 		locationId: location.id,
 		modelNumber: "Hilo Challenge",
@@ -348,7 +348,7 @@ const getHiloChallengeDevices = (location: Location): Device[] => [
 	{
 		assetId: `plannedAM-hilo-challenge-${location.id}`,
 		id: location.id + 103,
-		name: `Planned AM - Hilo Challenge ${location.name}`,
+		name: `Planned AM Hilo Challenge ${location.name}`,
 		type: "Challenge",
 		locationId: location.id,
 		modelNumber: "Hilo Challenge",
@@ -357,7 +357,7 @@ const getHiloChallengeDevices = (location: Location): Device[] => [
 	{
 		assetId: `plannedPM-hilo-challenge-${location.id}`,
 		id: location.id + 104,
-		name: `Planned PM - Hilo Challenge ${location.name}`,
+		name: `Planned PM Hilo Challenge ${location.name}`,
 		type: "Challenge",
 		locationId: location.id,
 		modelNumber: "Hilo Challenge",
@@ -366,10 +366,14 @@ const getHiloChallengeDevices = (location: Location): Device[] => [
 	{
 		assetId: `inProgress-hilo-challenge-${location.id}`,
 		id: location.id + 105,
-		name: `In Progress - Hilo Challenge ${location.name}`,
+		name: `In Progress Hilo Challenge ${location.name}`,
 		type: "Challenge",
 		locationId: location.id,
 		modelNumber: "Hilo Challenge",
 		identifier: `inProgress-hilo-challenge-${location.id}`,
 	},
 ];
+
+function cleanupDeviceName(name: string): string {
+	return name.replace(/[^a-zA-Z0-9'\s]/g, " ").trim();
+}


### PR DESCRIPTION
# What Changed

Compatibilité avec homebridge 2.0

## Release Notes

* BREAKING: Les thermostats fonctionnent maintenant en mode HEAT plutôt que AUTO fixes #36 
* Compatibilité avec homebridge 2.0
* Les instructions dans la configuration sont maintenant affiché en français aussi

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>3.0.0--canary.57.bfcf4c2.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install homebridge-hilo@3.0.0--canary.57.bfcf4c2.0
  # or 
  yarn add homebridge-hilo@3.0.0--canary.57.bfcf4c2.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
