### PR TITLE
Fix access token expiration

### DIFF
--- a/src/hiloApi.ts
+++ b/src/hiloApi.ts
@@ -131,7 +131,7 @@ export async function setupAutoRefreshToken(
 					unableToLogin(e);
 				}
 			}
-		}, expiresInSeconds / 60 - 5); // 5 minutes before expiration
+		}, (expiresInSeconds - 5 * 60) * 1000); // 5 minutes before expiration
 	}
 }
 

--- a/src/hiloApi.ts
+++ b/src/hiloApi.ts
@@ -108,8 +108,10 @@ export async function negotiate() {
 
 export const getWsAccessToken = () => wsAccessToken || "";
 
-export async function setupAutoRefreshToken(expiresIn: number | undefined) {
-	if (!expiresIn) {
+export async function setupAutoRefreshToken(
+	expiresInSeconds: number | undefined
+) {
+	if (!expiresInSeconds) {
 		getLogger().debug("Refreshing token");
 		try {
 			await refreshTokenRequest();
@@ -129,7 +131,7 @@ export async function setupAutoRefreshToken(expiresIn: number | undefined) {
 					unableToLogin(e);
 				}
 			}
-		}, expiresIn * 1000 - 1000 * 60 * 5); // 5 minutes before expiration
+		}, expiresInSeconds / 60 - 5); // 5 minutes before expiration
 	}
 }
 


### PR DESCRIPTION
fixes #58 
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>2.0.2--canary.59.3a7281d.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install homebridge-hilo@2.0.2--canary.59.3a7281d.0
  # or 
  yarn add homebridge-hilo@2.0.2--canary.59.3a7281d.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
